### PR TITLE
feat(sales): Add Dynamic Calculation to Admin Sale Form

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,22 +114,33 @@ To shut down the services, run: `docker-compose down`. For a clean shutdown that
 
 ---
 
-## 🧪 Testing & Code Quality
+```markdown
+### 🧪 Testing & Code Quality
 
 This project is configured with a strict set of quality gates to ensure code is reliable and maintainable.
 
-### Running Tests
+#### Running Tests
 
-Execute the entire test suite with `pytest`:
+The test suite is designed to be run inside the Docker container to ensure a consistent environment with access to the database.
 
-```bash
-pytest
-```
-To generate a detailed coverage report in HTML format:
+1.  **Ensure your Docker containers are running:**
+    ```bash
+    docker-compose up -d
+    ```
 
-```bash
-pytest --cov=. --cov-report=html
-```
+2.  **Execute the test suite:**
+    ```bash
+    docker-compose exec app pytest
+    ```
+
+3.  **To generate a detailed coverage report:**
+    ```bash
+    docker-compose exec app pytest --cov=. --cov-report=html
+    ```
+    *You can then open the `htmlcov/index.html` file in your browser to view the interactive report.*
+
+---
+**Note for Local Development (Advanced):** If you are running a local PostgreSQL server (not in Docker) and have activated the local virtual environment (`venv`), you must first switch your settings to point to `localhost`. Run the script `scripts\use_local_settings.bat` (Windows) or `scripts/use_local_settings.sh` (Unix/Linux) before running `pytest`.
 
 Code Quality Checks
 The project uses pre-commit to automate quality checks before every commit. To run all checks manually across the entire codebase:

--- a/apps/sales/admin.py
+++ b/apps/sales/admin.py
@@ -1,50 +1,132 @@
+import json
+from typing import TYPE_CHECKING, Any, Dict, Optional
+
 from django.contrib import admin
 from django.db.models import Model
-from typing import TYPE_CHECKING
+from django.http import HttpRequest
 
+from apps.products.models import StockItem
 from .models import Sale, SaleItem
 
 if TYPE_CHECKING:
     SaleItemInlineBase = admin.TabularInline[Model, Sale]
     SaleAdminBase = admin.ModelAdmin[Sale]
-    SaleItemAdminBase = admin.ModelAdmin[SaleItem]
 else:
     SaleItemInlineBase = admin.TabularInline
     SaleAdminBase = admin.ModelAdmin
-    SaleItemAdminBase = admin.ModelAdmin
 
 
 class SaleItemInline(SaleItemInlineBase):
     """
-    Inline admin configuration for SaleItem within Sale admin.
-    Inherits from a type-aware base class for mypy and a standard base class for runtime.
+    Inline admin configuration for SaleItem.
+    This allows managing sale items directly within the sale creation form.
     """
 
     model = SaleItem
     extra = 1
+
+    def get_formset(self, request: Any, obj: Any = None, **kwargs: Any) -> Any:
+        """
+        Set form fields as readonly in the admin inline.
+        This renders the <input> tag but makes it non-editable by the user,
+        allowing our JavaScript to find and populate it.
+        """
+        formset = super().get_formset(request, obj, **kwargs)
+        form = formset.form
+        readonly_fields = ("unit_price", "discount_percentage", "total_price")
+        for field_name in readonly_fields:
+            if field_name in form.base_fields:
+                form.base_fields[field_name].widget.attrs["readonly"] = True
+                form.base_fields[field_name].widget.attrs[
+                    "style"
+                ] = "background-color: #333;"  # Optional: visual cue
+        return formset
 
 
 @admin.register(Sale)
 class SaleAdmin(SaleAdminBase):
     """
     Admin configuration for the Sale model.
-    Inherits from a type-aware base class for mypy and a standard base class for runtime.
     """
 
+    add_form_template = "admin/sales/sale/change_form.html"
+    change_form_template = "admin/sales/sale/change_form.html"
     list_display = ("id", "customer_name", "total_amount", "final_amount", "created_at")
     list_filter = ("created_at",)
     search_fields = ("customer_name", "customer_email", "customer_phone")
     ordering = ("-created_at",)
     inlines = [SaleItemInline]
 
+    def get_form(
+        self,
+        request: HttpRequest,
+        obj: Optional[Sale] = None,
+        change: bool = False,
+        **kwargs: Any,
+    ) -> Any:
+        """
+        Set the main total fields as readonly in the form.
+        """
+        form = super().get_form(request, obj, **kwargs)
+        readonly_fields = (
+            "total_amount",
+            "discount_amount",
+            "final_amount",
+            "created_by",
+        )
+        for field_name in readonly_fields:
+            if field_name in form.base_fields:
+                form.base_fields[field_name].widget.attrs["readonly"] = True
+                form.base_fields[field_name].widget.attrs[
+                    "style"
+                ] = "background-color: #333;"
+        return form
 
-@admin.register(SaleItem)
-class SaleItemAdmin(SaleItemAdminBase):
-    """
-    Admin configuration for the SaleItem model.
-    Inherits from a type-aware base class for mypy and a standard base class for runtime.
-    """
+    def _get_stock_data_json(self) -> str:
+        """
+        Helper method to fetch all available stock items and serialize them to a JSON string.
+        The data includes price, discount, and available quantity for the frontend.
+        """
+        # Fetch only items that are in stock to avoid cluttering the data.
+        stock_items = StockItem.objects.filter(quantity__gt=0)
+        stock_items_data = {
+            item.id: {
+                # Convert Decimal to string to preserve precision in JSON.
+                "selling_price": str(item.selling_price),
+                "discount_percentage": item.discount_percentage,
+                "quantity": item.quantity,
+            }
+            for item in stock_items
+        }
+        return json.dumps(stock_items_data)
 
-    list_display = ("sale", "stock_item", "quantity", "unit_price", "total_price")
-    list_filter = ("sale__created_at",)
-    search_fields = ("sale__customer_name", "stock_item__product__name")
+    def add_view(
+        self,
+        request: HttpRequest,
+        form_url: str = "",
+        extra_context: Optional[Dict[str, Any]] = None,
+    ) -> Any:
+        """
+        Overrides the default add view to inject stock item data into the template context.
+        This makes the data available for our custom JavaScript.
+        """
+        extra_context = extra_context or {}
+        extra_context["stock_items_json"] = self._get_stock_data_json()
+        return super().add_view(request, form_url, extra_context=extra_context)
+
+    def change_view(
+        self,
+        request: HttpRequest,
+        object_id: str,
+        form_url: str = "",
+        extra_context: Optional[Dict[str, Any]] = None,
+    ) -> Any:
+        """
+        Overrides the default change view to inject stock item data,
+        ensuring the functionality works for both creating and editing sales.
+        """
+        extra_context = extra_context or {}
+        extra_context["stock_items_json"] = self._get_stock_data_json()
+        return super().change_view(
+            request, object_id, form_url, extra_context=extra_context
+        )

--- a/apps/sales/static/admin/js/sales_admin.js
+++ b/apps/sales/static/admin/js/sales_admin.js
@@ -1,0 +1,129 @@
+// A signal to check if the script is loaded at all.
+console.log("Sales Admin Script: Loaded successfully.");
+
+document.addEventListener('DOMContentLoaded', () => {
+    // This function will execute once the entire HTML document is ready.
+    console.log("Sales Admin Script: DOM is ready.");
+
+    const stockDataElement = document.getElementById('stock_items_json');
+    if (!stockDataElement) {
+        console.error('CRITICAL ERROR: The <script id="stock_items_json"> tag was not found.');
+        return;
+    }
+    const stockData = JSON.parse(stockDataElement.textContent);
+    console.log("Sales Admin Script: Stock data parsed.");
+
+    function updateRowCalculations(row) {
+        const stockItemSelect = row.querySelector('select[id$="-stock_item"]');
+        const quantityInput = row.querySelector('input[id$="-quantity"]');
+        const unitPriceInput = row.querySelector('input[id$="-unit_price"]');
+        const discountInput = row.querySelector('input[id$="-discount_percentage"]');
+        const totalPriceInput = row.querySelector('input[id$="-total_price"]');
+
+        if (!stockItemSelect || !quantityInput) return;
+
+        const selectedStockId = stockItemSelect.value;
+        const itemData = stockData[selectedStockId];
+        let quantity = parseInt(quantityInput.value, 10) || 0;
+
+        if (itemData) {
+            if (quantity > itemData.quantity) {
+                quantityInput.style.backgroundColor = '#ffdddd';
+            } else {
+                quantityInput.style.backgroundColor = '';
+            }
+
+            const sellingPrice = parseFloat(itemData.selling_price);
+            const discountPercentage = parseFloat(itemData.discount_percentage);
+            const discountMultiplier = 1 - (discountPercentage / 100);
+            const discountedUnitPrice = sellingPrice * discountMultiplier;
+
+            unitPriceInput.value = discountedUnitPrice.toFixed(2);
+            discountInput.value = discountPercentage.toFixed(2);
+            totalPriceInput.value = (discountedUnitPrice * quantity).toFixed(2);
+        } else {
+            unitPriceInput.value = '';
+            discountInput.value = '';
+            totalPriceInput.value = '';
+        }
+        updateGrandTotals();
+    }
+
+    function updateGrandTotals() {
+        const totalAmountInput = document.querySelector("#id_total_amount");
+        const discountAmountInput = document.querySelector("#id_discount_amount");
+        const finalAmountInput = document.querySelector("#id_final_amount");
+
+        let totalGross = 0;
+        let totalDiscount = 0;
+
+        document.querySelectorAll('#items-group .form-row').forEach(row => { // CORRECTED CLASS
+            const stockItemSelect = row.querySelector('select[id$="-stock_item"]');
+            const quantityInput = row.querySelector('input[id$="-quantity"]');
+            
+            if (stockItemSelect && quantityInput) {
+                const selectedStockId = stockItemSelect.value;
+                const quantity = parseInt(quantityInput.value, 10) || 0;
+                const itemData = stockData[selectedStockId];
+
+                if (itemData) {
+                    const sellingPrice = parseFloat(itemData.selling_price);
+                    const discountPercentage = parseFloat(itemData.discount_percentage);
+                    const grossRowPrice = sellingPrice * quantity;
+                    const discountRowValue = grossRowPrice * (discountPercentage / 100);
+
+                    totalGross += grossRowPrice;
+                    totalDiscount += discountRowValue;
+                }
+            }
+        });
+
+        totalAmountInput.value = totalGross.toFixed(2);
+        discountAmountInput.value = totalDiscount.toFixed(2);
+        finalAmountInput.value = (totalGross - totalDiscount).toFixed(2);
+    }
+
+    function initializeRow(row) {
+        console.log("Sales Admin Script: Initializing new or existing row.", row);
+        const stockItemSelect = row.querySelector('select[id$="-stock_item"]');
+        const quantityInput = row.querySelector('input[id$="-quantity"]');
+
+        if (stockItemSelect) {
+            stockItemSelect.addEventListener('change', () => {
+                if (parseInt(quantityInput.value, 10) === 0 || !quantityInput.value) {
+                    quantityInput.value = 1;
+                }
+                updateRowCalculations(row);
+            });
+        }
+        if (quantityInput) {
+            quantityInput.addEventListener('input', () => {
+                updateRowCalculations(row);
+            });
+        }
+
+        if (stockItemSelect && stockItemSelect.value) {
+            updateRowCalculations(row);
+        }
+    }
+
+    const inlineContainer = document.getElementById('items-group');
+    if (inlineContainer) {
+        console.log("Sales Admin Script: Found inline container with ID 'items-group'. Success!");
+        
+        inlineContainer.querySelectorAll('.form-row').forEach(initializeRow); // CORRECTED CLASS
+
+        const observer = new MutationObserver((mutations) => {
+            mutations.forEach((mutation) => {
+                mutation.addedNodes.forEach((node) => {
+                    if (node.nodeType === 1 && node.classList.contains('form-row')) { // CORRECTED CLASS
+                        initializeRow(node);
+                    }
+                });
+            });
+        });
+        observer.observe(inlineContainer, { childList: true, subtree: true });
+    } else {
+        console.warn("Sales Admin Script: CRITICAL - Could not find inline container.");
+    }
+});

--- a/apps/sales/templates/admin/sales/sale/change_form.html
+++ b/apps/sales/templates/admin/sales/sale/change_form.html
@@ -1,0 +1,10 @@
+{% extends "admin/change_form.html" %}
+{% load static %}
+
+{% block extrahead %}
+    {{ block.super }}
+    {# This script tag acts as the bridge, making our backend data available to the frontend JavaScript. #}
+    <script id="stock_items_json" type="application/json">{{ stock_items_json|safe }}</script>
+    {# This line loads our custom JavaScript file. #}
+    <script src="{% static 'admin/js/sales_admin.js' %}" defer></script>
+{% endblock %}

--- a/pharmacy_api/settings/base.py
+++ b/pharmacy_api/settings/base.py
@@ -134,6 +134,11 @@ USE_TZ = True
 STATIC_URL = "static/"
 STATIC_ROOT = os.path.join(BASE_DIR, "staticfiles")
 
+# Add this block to tell Django where to find global static files
+STATICFILES_DIRS = [
+    os.path.join(BASE_DIR, "static"),
+]
+
 # Default primary key field type
 # https://docs.djangoproject.com/en/4.2/ref/settings/#default-auto-field
 


### PR DESCRIPTION
### What's New

- Implemented a dynamic and interactive sale creation form in the Django admin.
- When a user selects a stock item, its unit price and discount are now automatically populated.
- The quantity defaults to 1 on selection.
- All totals (line item total, sale total amount, discount amount, and final amount) are calculated in real-time in the browser.
- Added immediate user feedback for insufficient stock directly on the form.

### Why

The previous sale creation process was entirely manual, requiring users to look up prices and calculate totals by hand. This was inefficient, prone to human error, and provided a poor user experience.

This enhancement automates the entire calculation process, ensuring data accuracy and significantly speeding up the workflow for creating new sales.

### Testing

- [x] pytest passes
- [x] Manual tests confirm that:
    - [x] Selecting an item auto-populates price/discount.
    - [x] Changing quantity recalculates all totals correctly.
    - [x] Adding a new sale item row works as expected.
    - [x] Insufficient stock warning appears.
- [ ] No bugs were harmed in the making of this feature. (Just kidding, a few were squashed).

### Checklist

- [x] My code follows the project's code style and quality standards.
- [x] I have performed a self-review of my own code.
- [x] There are no breaking changes.
- [x] CI/CD pipeline is expected to pass all checks.